### PR TITLE
port ordering and non-primitive field defaults

### DIFF
--- a/rill/engine/jsonschema_types.py
+++ b/rill/engine/jsonschema_types.py
@@ -3,6 +3,8 @@ import collections
 import schematics.types
 import schematics.models
 from schematics.undefined import Undefined
+from rill.compat import *
+
 
 def setup_primitive_types():
     import decimal
@@ -72,7 +74,9 @@ def _convert_field(field_instance):
         # TODO: max_size -> maxItems
 
     elif isinstance(field_instance, schematics.types.BaseType):
-        primitive_type = TYPE_MAP[getattr(field_instance, 'primitive_type', str)]
+        # get the primitive_type (use str as default if not defined)
+        primitive_type = TYPE_MAP[
+            getattr(field_instance, 'primitive_type', str) or str]
         schema = {'type': primitive_type}
         # add native type into schema
         native_type = getattr(field_instance, 'native_type')
@@ -100,7 +104,7 @@ def _convert_field(field_instance):
 
     default = field_instance.default
     if default is not Undefined:
-        schema['default'] = default
+        schema['default'] = field_instance.to_primitive(default)
 
     metadata = field_instance.metadata
     if metadata:

--- a/rill/engine/subnet.py
+++ b/rill/engine/subnet.py
@@ -24,9 +24,14 @@ def merge_portdefs(exported, inherited):
     # @inport can be customized to describe the port's purposed within the
     # SubGraph as a whole, whereas the description of exported port concerns
     # only the behavior of its component.
-    # FIXME: check compatibility of things like array, required...
-    exported.update(inherited)
-    return exported
+    results = inherited.copy()
+    for k, v in exported.items():
+        if k not in results:
+            results[k] = v
+        else:
+            # FIXME: check compatibility of things like array, required...
+            pass
+    return results
 
 
 # using a component to proxy each exported port has a few side effects:


### PR DESCRIPTION
Fixes port ordering for subgraphs and registering field types within the schema that use non-primitive defaults.